### PR TITLE
update chrome driver to match latest stable chrome version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,16 @@ RUN apt-get update \
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz \
+RUN wget -q https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz \
 	&& tar xvzf geckodriver-*.tar.gz \
 	&& rm geckodriver-*.tar.gz \
 	&& mv geckodriver /usr/local/bin \
 	&& chmod a+x /usr/local/bin/geckodriver
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+# install chrome and chromedriver in one run command to clear build caches for new versions (both version need to match)
+RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
 	&& dpkg -i google-chrome*.deb \
-	&& rm google-chrome*.deb
-RUN wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip \
+	&& rm google-chrome*.deb \
+    && wget -q https://chromedriver.storage.googleapis.com/80.0.3987.106/chromedriver_linux64.zip \
 	&& unzip chromedriver_linux64.zip \
 	&& rm chromedriver_linux64.zip \
 	&& mv chromedriver /usr/local/bin \


### PR DESCRIPTION
When rebuilding the image on our CI the version of chrome and chromedriver no longer matched:
```
SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 74
  (Driver info: chromedriver=74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29}),platform=Linux 4.9.0-11-amd64 x86_64)
```

This updates the chromedriver url to match the latest stable chrome. Also because chrome and chromedriver should always have matching versions, the install is now done in one run command (clearing the cache for the chrome download layer as well when updating the chromedriver url, to prevent systems on which the image was already build reusing their cache layer for google chrome)

Info @wt-io-it