### PR TITLE
Allow an individual test suite to run when need

### DIFF
--- a/scripts/run_suite.sh
+++ b/scripts/run_suite.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-CMD="robot --console verbose --outputdir /reports /suites"
+
+# Run an individual test suite if the TEST_SUITE environmental variable is set.
+if [ -z "$TEST_SUITE" ]; then
+    TEST_SUITE=""
+fi
+
+CMD="robot $ROBOT_VARIABLES --console verbose --outputdir /reports /suites/$TEST_SUITE"
 
 echo ${CMD}
 

--- a/scripts/run_suite.sh
+++ b/scripts/run_suite.sh
@@ -7,7 +7,7 @@ if [ -z "$TEST_SUITE" ]; then
     TEST_SUITE=""
 fi
 
-CMD="robot $ROBOT_VARIABLES --console verbose --outputdir /reports /suites/$TEST_SUITE"
+CMD="robot --console verbose --outputdir /reports /suites/$TEST_SUITE"
 
 echo ${CMD}
 


### PR DESCRIPTION
Run an individual test suite if the TEST_SUITE environmental variable is set.

Example:
```
version: '3.3'
services:
    test:
        network_mode: host
        image: ypasmk/robot-framework
        shm_size: "256M"
        environment:
            USERNAME: Ipatios Asmanidis
            TEST_SUITE: test_login.robot
        volumes: [
           "$PWD/output:/output",
           "$PWD/suites:/suites",
           "$PWD/scripts:/scripts",
           "$PWD/reports:/reports"
        ]
```

Since the TEST_SUITE environmental variable is given, it changes the command from:
```
robot --console verbose --outputdir /reports /suites
```
to

```
robot --console verbose --outputdir /reports /suites/test_login.robot"
```
