### PR TITLE
[FIX] requirements: pillow 7.1.0 is not available in pip (python2?)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ natsort==6.0.0
 ndg-httpsclient==0.5.1
 openpyxl==2.6.2
 paramiko==2.4.2
-Pillow==7.1.0
+Pillow==6.2.2
 pyasn1==0.4.5
 pycparser==2.19
 PyNaCl==1.3.0


### PR DESCRIPTION
@dependabot broke the build with https://github.com/ypasmk/robot-framework-docker/pull/13

this pull request uses the latest python2.7 compatible Pillow version

the build error with pillow 7.1.0:
```
ERROR: Could not find a version that satisfies the requirement Pillow==7.1.0 (from -r requirements.txt (line 23)) (from versions: 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7.0, 1.7.1, 1.7.2, 1.7.3, 1.7.4, 1.7.5, 1.7.6, 1.7.7, 1.7.8, 2.0.0, 2.1.0, 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.3.2, 2.4.0, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.8.0, 2.8.1, 2.8.2, 2.9.0, 3.0.0, 3.1.0rc1, 3.1.0, 3.1.1, 3.1.2, 3.2.0, 3.3.0, 3.3.1, 3.3.2, 3.3.3, 3.4.0, 3.4.1, 3.4.2, 4.0.0, 4.1.0, 4.1.1, 4.2.0, 4.2.1, 4.3.0, 5.0.0, 5.1.0, 5.2.0, 5.3.0, 5.4.0, 5.4.1, 6.0.0, 6.1.0, 6.2.0, 6.2.1, 6.2.2)
ERROR: No matching distribution found for Pillow==7.1.0 (from -r requirements.txt (line 23))
```